### PR TITLE
Repair link to Java client GitHub repository

### DIFF
--- a/site/java-client.xml
+++ b/site/java-client.xml
@@ -165,7 +165,7 @@ limitations under the License.
       <repository type="github" shortname="rabbitmq-java-client"
         url="https://github.com/rabbitmq/rabbitmq-java-client"/>
       <repository type="github" shortname="rabbitmq-codegen"
-        url="https://github.com/rabbitmq/rabbitmq-codegen/"/>
+        url="https://github.com/rabbitmq/rabbitmq-codegen"/>
     </repositories>
 
     <h2>Support</h2>


### PR DESCRIPTION
Resolve issue #75.

Remove last slash in url which break link generation.
